### PR TITLE
HLX-2918 - Can't backspace 0 in requirement Estimated Value field

### DIFF
--- a/projects/compass-form/src/lib/compass-dollar-control/dollar-input.component.ts
+++ b/projects/compass-form/src/lib/compass-dollar-control/dollar-input.component.ts
@@ -27,6 +27,9 @@ export class DollarInputComponent implements ControlValueAccessor {
   key: string;
   @Input()
   errorMessage: string;
+  @Input()
+  allowDecimal: boolean = true;
+
   @ViewChild('input')
   inputRef: ElementRef<HTMLInputElement>;
 
@@ -58,10 +61,16 @@ export class DollarInputComponent implements ControlValueAccessor {
   onKeyup(event: KeyboardEvent) {
     const target = (event.target as HTMLInputElement);
     const newValue = target.value;
-    const vaidInput = !!/^-?[0-9]*(\.[0-9]?[0-9]?)?$/.exec(newValue);
-    const numValue = +newValue;
+
+    const validInput = this.allowDecimal
+      ? !!/^-?[0-9]*(\.[0-9]?[0-9]?)?$/.exec(newValue)
+      : !!/^-?[0-9]*$/.exec(newValue);
+    const numValue = this.allowDecimal
+      ? +newValue
+      : Math.floor(+newValue);
+
     const inBounds = this.checkBounds(numValue);
-    if (vaidInput && inBounds) {
+    if (validInput && inBounds) {
       this.currentStrValue = newValue;
       this.onchange(numValue);
     } else {
@@ -99,6 +108,9 @@ export class DollarInputComponent implements ControlValueAccessor {
       middlePart = middlePart.substr(0, middlePart.length - 3);
     }
     formatedMiddlePart = middlePart + formatedMiddlePart;
-    return match[1] +  formatedMiddlePart + '.' + (match[3] + '00').substr(0, 2);
+
+    return this.allowDecimal
+      ? match[1] +  formatedMiddlePart + '.' + (match[3] + '00').substr(0, 2)
+      : match[1] +  formatedMiddlePart;
   }
 }

--- a/projects/compass-form/src/lib/compass-estimated-dollar-control/compass-estimated-dollar-control.component.html
+++ b/projects/compass-form/src/lib/compass-estimated-dollar-control/compass-estimated-dollar-control.component.html
@@ -1,6 +1,12 @@
-<mat-form-field [hintLabel]="snapshot.hint" [formGroup]="compassForm.ngForm">
-  <span matPrefix>$ &nbsp;</span>
-  <input matInput [placeholder]="snapshot.label + (snapshot.required ? ' *':'' )" [formControlName]="snapshot.key" type="number"
-    [min]="snapshot.min" [max]="snapshot.max" step="1" (keypress)="onKeypress($event)" [attr.data-compassFormKey]="snapshot.key" />
-  <mat-error>{{snapshot.errorMessage}}</mat-error>
-</mat-form-field>
+<ng-container [formGroup]="compassForm.ngForm">
+  <compass-dollar-input
+    [hintLabel]="snapshot.hint"
+    [placeholder]="snapshot.label + (snapshot.required ? ' *':'' )"
+    [min]="snapshot.min"
+    [max]="snapshot.max" step="1"
+    [key]="snapshot.key"
+    [formControlName]="snapshot.key"
+    [errorMessage]="snapshot.errorMessage"
+    [allowDecimal]="false"
+  ></compass-dollar-input>
+  </ng-container>

--- a/projects/compass-form/src/lib/compass-estimated-dollar-control/compass-estimated-dollar-control.component.ts
+++ b/projects/compass-form/src/lib/compass-estimated-dollar-control/compass-estimated-dollar-control.component.ts
@@ -17,12 +17,4 @@ export class CompassEstimatedDollarControlComponent<ModelType> implements ICompa
     get snapshot() {
         return this.compassControl.snapshot;
     }
-
-    onKeypress(event: KeyboardEvent) {
-        // Kill any scientific notation or decimal keystrokes normally permitted by number field
-        if (event.key === 'e' || event.key === '+' || event.key === '-' || event.key === '.') {
-            event.preventDefault();
-            return;
-        }
-    }
 }


### PR DESCRIPTION
Modified the `dollar-input.component` to support whole dollars by adding the `allowDecimal` input.  The `compass-estimated-dollar-control.component` now simply uses a `dollar-input.component` with `allowDecimal=false`.

This helps make the UX of the dollar and estimated dollar inputs be the same.